### PR TITLE
If protocol is not known then show unknown

### DIFF
--- a/client/src/lib/url-parser.ts
+++ b/client/src/lib/url-parser.ts
@@ -32,7 +32,8 @@ export function parseURL(inputUrl: string): ParseURLResult {
 
     let urlToParse = inputUrl.trim();
 
-    if (!KNOWN_PROTOCOLS_REGEX.test(urlToParse)) {
+    const userProvidedProtocol = KNOWN_PROTOCOLS_REGEX.test(urlToParse);
+    if (!userProvidedProtocol) {
       urlToParse = `https://${urlToParse}`;
     }
 
@@ -47,7 +48,7 @@ export function parseURL(inputUrl: string): ParseURLResult {
     });
 
     const components: URLComponents = {
-      protocol: url.protocol.slice(0, -1),
+      protocol: userProvidedProtocol ? url.protocol.slice(0, -1) : "unknown",
       hostname: url.hostname,
       port: url.port || undefined,
       pathname: url.pathname,

--- a/tests/e2e/tools/url-to-json.spec.ts
+++ b/tests/e2e/tools/url-to-json.spec.ts
@@ -293,4 +293,21 @@ test.describe("URL to JSON Tool", () => {
     expect(parsed.queryParams).toEqual({ id: "123" });
     await expectNoErrors(page);
   });
+
+  test("should show 'unknown' protocol when no protocol is entered", async ({
+    page,
+  }) => {
+    const urlInput = page.getByTestId("url-input");
+
+    await urlInput.fill("example.com");
+
+    const jsonOutput = page.locator("#output .cm-content");
+    await expect(jsonOutput).toBeVisible();
+    const outputText = await jsonOutput.textContent();
+    const parsed = JSON.parse(outputText || "{}");
+
+    expect(parsed.protocol).toBe("unknown");
+    expect(parsed.hostname).toBe("example.com");
+    await expectNoErrors(page);
+  });
 });

--- a/tests/lib/url-parser.test.ts
+++ b/tests/lib/url-parser.test.ts
@@ -127,10 +127,18 @@ describe("parseURL", () => {
   });
 
   describe("protocol handling", () => {
-    it("adds https:// when protocol is missing", () => {
+    it("shows 'unknown' when protocol is missing", () => {
       const result = parseURL("example.com");
       expect(result.success).toBe(true);
-      expect(result.components.protocol).toBe("https");
+      expect(result.components.protocol).toBe("unknown");
+    });
+
+    it("still parses hostname and TLD when protocol is missing", () => {
+      const result = parseURL("example.com");
+      expect(result.success).toBe(true);
+      expect(result.components.hostname).toBe("example.com");
+      expect(result.components.domain).toBe("example");
+      expect(result.components.tld).toBe("com");
     });
 
     it("preserves http protocol", () => {


### PR DESCRIPTION
## Summary

Fixes #285

When a user enters a bare hostname (e.g. `example.com`) into the URL to JSON
tool without specifying a protocol, the parser was internally prepending
`https://` to satisfy the `URL` API and then returning `protocol: "https"` in
the output — a value the user never typed.

## Changes

- **`client/src/lib/url-parser.ts`**: Before the `https://` prepend, capture
  whether the user's input contained a known protocol via `KNOWN_PROTOCOLS_REGEX`.
  If not, return `protocol: "unknown"` instead of the auto-prepended value. All
  other fields (`hostname`, `domain`, `tld`, etc.) continue to resolve correctly
  via the internal prepend.

- **`tests/lib/url-parser.test.ts`**: Updated the existing
  `"adds https:// when protocol is missing"` test to assert `"unknown"` and
  renamed it to reflect correct behaviour. Added a companion test verifying that
  `hostname`, `domain`, and `tld` still parse correctly when no protocol is given.

- **`tests/e2e/tools/url-to-json.spec.ts`**: New end-to-end test — inputs
  `example.com`, asserts `protocol === "unknown"` and `hostname === "example.com"`.
