### PR TITLE
Fix: show error for year with more than 4 digits in Time Formatter

### DIFF
--- a/client/src/pages/tools/time-formatter.tsx
+++ b/client/src/pages/tools/time-formatter.tsx
@@ -403,11 +403,7 @@ export default function TimeFormatter() {
 
       {/* Year validation error */}
       {yearError ? (
-        <Alert
-          variant="destructive"
-          data-testid="year-error"
-          className="mb-6"
-        >
+        <Alert variant="destructive" data-testid="year-error" className="mb-6">
           <AlertDescription>{yearError}</AlertDescription>
         </Alert>
       ) : null}

--- a/client/src/pages/tools/time-formatter.tsx
+++ b/client/src/pages/tools/time-formatter.tsx
@@ -8,8 +8,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TimezoneSelector } from "@/components/ui/timezone-selector";
 import { getUserTimezone } from "@/lib/time-tools";
-import { Clock, Copy, Check, AlertCircle } from "lucide-react";
+import { Clock, Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   ResetButton,
   ClearButton,
@@ -402,13 +403,13 @@ export default function TimeFormatter() {
 
       {/* Year validation error */}
       {yearError ? (
-        <div
+        <Alert
+          variant="destructive"
           data-testid="year-error"
-          className="flex items-center gap-2 mb-6 px-4 py-3 rounded-lg border border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-400"
+          className="mb-6"
         >
-          <AlertCircle className="h-4 w-4 shrink-0" />
-          <span className="text-sm">{yearError}</span>
-        </div>
+          <AlertDescription>{yearError}</AlertDescription>
+        </Alert>
       ) : null}
 
       {/* Formatted Times */}

--- a/client/src/pages/tools/time-formatter.tsx
+++ b/client/src/pages/tools/time-formatter.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TimezoneSelector } from "@/components/ui/timezone-selector";
 import { getUserTimezone } from "@/lib/time-tools";
-import { Clock, Copy, Check } from "lucide-react";
+import { Clock, Copy, Check, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   ResetButton,
@@ -31,6 +31,7 @@ export default function TimeFormatter() {
   const [inputTimezone, setInputTimezone] = useState(getUserTimezone());
   const [formats, setFormats] = useState<TimeFormat[]>([]);
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+  const [yearError, setYearError] = useState<string>("");
 
   // Set current date and time on load
   useEffect(() => {
@@ -45,12 +46,25 @@ export default function TimeFormatter() {
   useEffect(() => {
     if (inputDate && inputTime) {
       formatTime();
+    } else {
+      setYearError("");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputDate, inputTime, inputTimezone]);
 
   const formatTime = useCallback(() => {
     try {
+      // Reject years with more than 4 digits (> 9999)
+      const yearPart = inputDate.split("-")[0];
+      if (yearPart && yearPart.length > 4) {
+        setYearError(
+          "Invalid year: year must be 4 digits or fewer (max 9999)."
+        );
+        setFormats([]);
+        return;
+      }
+      setYearError("");
+
       // Create date object from input
       const dateTime = new Date(`${inputDate}T${inputTime}`);
 
@@ -291,6 +305,7 @@ export default function TimeFormatter() {
     setInputDate("");
     setInputTime("");
     setFormats([]);
+    setYearError("");
   };
 
   const hasModifiedData = inputDate.trim() !== "" && inputTime.trim() !== "";
@@ -384,6 +399,17 @@ export default function TimeFormatter() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Year validation error */}
+      {yearError ? (
+        <div
+          data-testid="year-error"
+          className="flex items-center gap-2 mb-6 px-4 py-3 rounded-lg border border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-400"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span className="text-sm">{yearError}</span>
+        </div>
+      ) : null}
 
       {/* Formatted Times */}
       {formats.length > 0 && (

--- a/tests/e2e/tools/time-formatter.spec.ts
+++ b/tests/e2e/tools/time-formatter.spec.ts
@@ -18,4 +18,35 @@ test.describe("Time Formatter Tool", () => {
     await expectNoErrors(page);
     await expectDefaultValue(page);
   });
+
+  test("should show an error when the year has more than 4 digits", async ({
+    page,
+  }) => {
+    const dateInput = page.getByTestId("input-date");
+
+    // Bypass the browser's native date-input UI controls by setting the value
+    // and firing synthetic change events that React's synthetic event system picks up.
+    await dateInput.evaluate(el => {
+      const input = el as HTMLInputElement;
+      const nativeValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value"
+      )?.set;
+      if (nativeValueSetter) {
+        nativeValueSetter.call(input, "12345-01-01");
+      }
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    // Error banner should appear
+    const yearError = page.getByTestId("year-error");
+    await expect(yearError).toBeVisible();
+    await expect(yearError).toContainText("4 digits");
+
+    // No formatted results should be shown
+    await expect(page.locator('[data-testid="format-0"]')).not.toBeVisible();
+
+    await expectNoErrors(page);
+  });
 });


### PR DESCRIPTION
Fixes #281

When a user typed a year with more than 4 digits (e.g. \`12345-01-01\`) into the Time Formatter's date input, the tool silently produced no output. The fix validates the year portion of the date string before attempting to format, and shows a clear error message.

## Changes

- **\`client/src/pages/tools/time-formatter.tsx\`**:
  - Added \`yearError\` state.
  - \`formatTime\` now checks the year segment of \`inputDate\`: if it has more than 4 characters (year > 9999), it sets an error message, clears the formatted results, and returns early.
  - \`handleClear\` and the input-change \`useEffect\` also clear \`yearError\` appropriately.
  - Added a red error banner (with \`AlertCircle\` icon) rendered between the input card and the results, tagged \`data-testid="year-error"\`.

- **\`tests/e2e/tools/time-formatter.spec.ts\`**: New test sets the date input to \`12345-01-01\` via the native value setter + synthetic events (bypassing the browser's date-picker UI), then asserts the error banner is visible, contains "4 digits", and no formatted results are shown.

