### PR TITLE
Add nanoseconds, and show NOW in the selected format

### DIFF
--- a/client/src/pages/tools/date-converter.tsx
+++ b/client/src/pages/tools/date-converter.tsx
@@ -110,7 +110,7 @@ const INPUT_FORMATS = [
   },
 ];
 
-// 20 Essential Date Formats for Developers
+// Essential Date Formats for Developers
 const DATE_FORMATS = [
   // Unix & Timestamps
   {
@@ -886,8 +886,9 @@ export default function DateConverter() {
               ) : null}
             </h2>
             <p className="text-slate-600 dark:text-slate-400">
-              Convert between 20 essential date formats: Unix timestamps, ISO
-              standards, RFC formats, regional formats, and database formats
+              Convert between {DATE_FORMATS.length} essential date formats: Unix
+              timestamps, ISO standards, RFC formats, regional formats, and
+              database formats
             </p>
           </div>
           <SecurityBanner variant="compact" />

--- a/client/src/pages/tools/date-converter.tsx
+++ b/client/src/pages/tools/date-converter.tsx
@@ -535,8 +535,9 @@ export default function DateConverter() {
     // Try Unix timestamp (nanoseconds)
     if (/^-?\d{19}$/.test(trimmed)) {
       try {
-        const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
-        const d = new Date(ms);
+        const ns = BigInt(trimmed);
+        const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+        const d = new Date(Number(msBig));
         if (!isNaN(d.getTime())) return d;
       } catch {
         // fall through

--- a/client/src/pages/tools/date-converter.tsx
+++ b/client/src/pages/tools/date-converter.tsx
@@ -367,8 +367,9 @@ export default function DateConverter() {
     if (format === "unixns") {
       if (!/^-?\d+$/.test(trimmed)) return null;
       try {
-        const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
-        const d = new Date(ms);
+        const ns = BigInt(trimmed);
+        const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+        const d = new Date(Number(msBig));
         return isNaN(d.getTime()) ? null : d;
       } catch {
         return null;

--- a/client/src/pages/tools/date-converter.tsx
+++ b/client/src/pages/tools/date-converter.tsx
@@ -368,7 +368,10 @@ export default function DateConverter() {
       if (!/^-?\d+$/.test(trimmed)) return null;
       try {
         const ns = BigInt(trimmed);
-        const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+        const ms1M = BigInt(1_000_000);
+        const msBig =
+          ns / ms1M -
+          (ns < BigInt(0) && ns % ms1M !== BigInt(0) ? BigInt(1) : BigInt(0));
         const d = new Date(Number(msBig));
         return isNaN(d.getTime()) ? null : d;
       } catch {
@@ -536,7 +539,10 @@ export default function DateConverter() {
     if (/^-?\d{19}$/.test(trimmed)) {
       try {
         const ns = BigInt(trimmed);
-        const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+        const ms1M = BigInt(1_000_000);
+        const msBig =
+          ns / ms1M -
+          (ns < BigInt(0) && ns % ms1M !== BigInt(0) ? BigInt(1) : BigInt(0));
         const d = new Date(Number(msBig));
         if (!isNaN(d.getTime())) return d;
       } catch {

--- a/client/src/pages/tools/date-converter.tsx
+++ b/client/src/pages/tools/date-converter.tsx
@@ -48,6 +48,11 @@ const INPUT_FORMATS = [
     label: "Unix Epoch (milliseconds)",
     description: "e.g., 1699123456000",
   },
+  {
+    value: "unixns",
+    label: "Unix Epoch (nanoseconds)",
+    description: "e.g., 1699123456000000000",
+  },
   // ISO Standards
   {
     value: "iso",
@@ -120,6 +125,13 @@ const DATE_FORMATS = [
     format: "unixms",
     pattern: "Epoch (milliseconds)",
     description: "Milliseconds since Jan 1, 1970",
+    category: "Timestamp",
+  },
+  {
+    name: "Unix Nanoseconds",
+    format: "unixns",
+    pattern: "Epoch (nanoseconds)",
+    description: "Nanoseconds since Jan 1, 1970",
     category: "Timestamp",
   },
 
@@ -341,13 +353,26 @@ export default function DateConverter() {
     if (format === "unix") {
       const num = parseInt(trimmed, 10);
       if (isNaN(num)) return null;
-      return new Date(num * 1000);
+      const d = new Date(num * 1000);
+      return isNaN(d.getTime()) ? null : d;
     }
 
     if (format === "unixms") {
       const num = parseInt(trimmed, 10);
       if (isNaN(num)) return null;
-      return new Date(num);
+      const d = new Date(num);
+      return isNaN(d.getTime()) ? null : d;
+    }
+
+    if (format === "unixns") {
+      if (!/^-?\d+$/.test(trimmed)) return null;
+      try {
+        const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
+        const d = new Date(ms);
+        return isNaN(d.getTime()) ? null : d;
+      } catch {
+        return null;
+      }
     }
 
     if (format === "iso") {
@@ -506,6 +531,17 @@ export default function DateConverter() {
       return new Date(parseInt(trimmed));
     }
 
+    // Try Unix timestamp (nanoseconds)
+    if (/^-?\d{19}$/.test(trimmed)) {
+      try {
+        const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
+        const d = new Date(ms);
+        if (!isNaN(d.getTime())) return d;
+      } catch {
+        // fall through
+      }
+    }
+
     // Try standard date parsing
     const date = new Date(trimmed);
     if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
@@ -530,6 +566,8 @@ export default function DateConverter() {
         return Math.floor(date.getTime() / 1000).toString();
       case "unixms":
         return date.getTime().toString();
+      case "unixns":
+        return (BigInt(date.getTime()) * BigInt(1_000_000)).toString();
       case "iso":
         return date.toISOString();
       case "isodate":
@@ -757,7 +795,7 @@ export default function DateConverter() {
   const convertDate = useCallback(() => {
     const date = parseInputDate(inputDate, inputFormat);
 
-    if (!date) {
+    if (!date || isNaN(date.getTime())) {
       const selectedFormat = INPUT_FORMATS.find(f => f.value === inputFormat);
       setFormats([
         {
@@ -799,8 +837,13 @@ export default function DateConverter() {
 
   const handleCurrentTime = () => {
     const now = new Date();
-    // Use the user's timezone for current time display
-    setInputDate(Math.floor(now.getTime() / 1000).toString());
+    // Map input format values that differ from their formatDate key
+    const inputFormatToFormatKey: Record<string, string> = {
+      shorttext: "short",
+      fulltext: "full",
+    };
+    const formatKey = inputFormatToFormatKey[inputFormat] ?? inputFormat;
+    setInputDate(formatDate(now, formatKey));
   };
 
   useEffect(() => {

--- a/tests/lib/date-converter.test.ts
+++ b/tests/lib/date-converter.test.ts
@@ -8,13 +8,26 @@ const parseInputDate = (input: string, format = "auto"): Date | null => {
   if (format === "unix") {
     const num = parseInt(trimmed, 10);
     if (isNaN(num)) return null;
-    return new Date(num * 1000);
+    const d = new Date(num * 1000);
+    return isNaN(d.getTime()) ? null : d;
   }
 
   if (format === "unixms") {
     const num = parseInt(trimmed, 10);
     if (isNaN(num)) return null;
-    return new Date(num);
+    const d = new Date(num);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  if (format === "unixns") {
+    if (!/^-?\d+$/.test(trimmed)) return null;
+    try {
+      const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
+      const d = new Date(ms);
+      return isNaN(d.getTime()) ? null : d;
+    } catch {
+      return null;
+    }
   }
 
   if (format === "iso") {
@@ -163,6 +176,16 @@ const parseInputDate = (input: string, format = "auto"): Date | null => {
     return new Date(parseInt(trimmed));
   }
 
+  if (/^-?\d{19}$/.test(trimmed)) {
+    try {
+      const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
+      const d = new Date(ms);
+      if (!isNaN(d.getTime())) return d;
+    } catch {
+      // fall through
+    }
+  }
+
   const date = new Date(trimmed);
   if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
     const [y, m, d] = trimmed.split("-").map(Number);
@@ -185,6 +208,8 @@ const formatDate = (date: Date, format: string): string => {
       return Math.floor(date.getTime() / 1000).toString();
     case "unixms":
       return date.getTime().toString();
+    case "unixns":
+      return (BigInt(date.getTime()) * BigInt(1_000_000)).toString();
     case "iso":
       return date.toISOString();
     case "isodate":
@@ -432,6 +457,23 @@ describe("Date Converter", () => {
         const result = parseInputDate("1705329045123", "unixms");
         expect(result).toBeInstanceOf(Date);
         expect(result!.toISOString()).toBe("2024-01-15T14:30:45.123Z");
+      });
+
+      it("should parse Unix timestamp (nanoseconds) with explicit format", () => {
+        const result = parseInputDate("1705329045123000000", "unixns");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.toISOString()).toBe("2024-01-15T14:30:45.123Z");
+      });
+
+      it("should parse Unix nanoseconds via auto-detect (19 digits)", () => {
+        const result = parseInputDate("1705329045123000000");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.toISOString()).toBe("2024-01-15T14:30:45.123Z");
+      });
+
+      it("should return null for nanosecond format with non-numeric input", () => {
+        const result = parseInputDate("not-a-number", "unixns");
+        expect(result).toBeNull();
       });
 
       it("should parse negative Unix timestamp for pre-epoch dates", () => {
@@ -688,6 +730,11 @@ describe("Date Converter", () => {
       it("should format Unix milliseconds correctly", () => {
         const result = formatDate(testDate, "unixms");
         expect(result).toBe("1705329045123");
+      });
+
+      it("should format Unix nanoseconds correctly", () => {
+        const result = formatDate(testDate, "unixns");
+        expect(result).toBe("1705329045123000000");
       });
     });
 

--- a/tests/lib/date-converter.test.ts
+++ b/tests/lib/date-converter.test.ts
@@ -179,8 +179,9 @@ const parseInputDate = (input: string, format = "auto"): Date | null => {
 
   if (/^-?\d{19}$/.test(trimmed)) {
     try {
-      const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
-      const d = new Date(ms);
+      const ns = BigInt(trimmed);
+      const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+      const d = new Date(Number(msBig));
       if (!isNaN(d.getTime())) return d;
     } catch {
       // fall through

--- a/tests/lib/date-converter.test.ts
+++ b/tests/lib/date-converter.test.ts
@@ -23,7 +23,10 @@ const parseInputDate = (input: string, format = "auto"): Date | null => {
     if (!/^-?\d+$/.test(trimmed)) return null;
     try {
       const ns = BigInt(trimmed);
-      const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+      const ms1M = BigInt(1_000_000);
+      const msBig =
+        ns / ms1M -
+        (ns < BigInt(0) && ns % ms1M !== BigInt(0) ? BigInt(1) : BigInt(0));
       const d = new Date(Number(msBig));
       return isNaN(d.getTime()) ? null : d;
     } catch {
@@ -180,7 +183,10 @@ const parseInputDate = (input: string, format = "auto"): Date | null => {
   if (/^-?\d{19}$/.test(trimmed)) {
     try {
       const ns = BigInt(trimmed);
-      const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+      const ms1M = BigInt(1_000_000);
+      const msBig =
+        ns / ms1M -
+        (ns < BigInt(0) && ns % ms1M !== BigInt(0) ? BigInt(1) : BigInt(0));
       const d = new Date(Number(msBig));
       if (!isNaN(d.getTime())) return d;
     } catch {
@@ -484,8 +490,48 @@ describe("Date Converter", () => {
         expect(result!.getTime()).toBe(-1);
       });
 
+      it("should parse negative unix nanoseconds (explicit format) for pre-epoch dates", () => {
+        // -1000000000000000000 ns = -1000000000 s = 1938-04-24
+        const result = parseInputDate("-1000000000000000000", "unixns");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.getFullYear()).toBe(1938);
+      });
+
+      it("should parse negative unix nanoseconds via auto-detect (19 digits)", () => {
+        const result = parseInputDate("-1000000000000000000");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.getFullYear()).toBe(1938);
+      });
+
+      it("should floor negative nanoseconds with remainder correctly", () => {
+        // -1 ns → floor(-0.000001 ms) = -1 ms
+        const result = parseInputDate("-1000000", "unixns");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.getTime()).toBe(-1);
+      });
+
+      it("should handle exact negative millisecond boundary in nanoseconds", () => {
+        // -1000000000 ns = exactly -1000 ms
+        const result = parseInputDate("-1000000000", "unixns");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.getTime()).toBe(-1000);
+      });
+
       it("should parse negative Unix timestamp for pre-epoch dates", () => {
         const result = parseInputDate("-1000000000");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.getFullYear()).toBe(1938);
+      });
+
+      it("should parse negative Unix milliseconds (explicit format) for pre-epoch dates", () => {
+        // -1000000000000 ms = -1000000000 s = 1938-04-24
+        const result = parseInputDate("-1000000000000", "unixms");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.getFullYear()).toBe(1938);
+      });
+
+      it("should parse negative Unix seconds (explicit format) for pre-epoch dates", () => {
+        const result = parseInputDate("-1000000000", "unix");
         expect(result).toBeInstanceOf(Date);
         expect(result!.getFullYear()).toBe(1938);
       });
@@ -743,6 +789,12 @@ describe("Date Converter", () => {
       it("should format Unix nanoseconds correctly", () => {
         const result = formatDate(testDate, "unixns");
         expect(result).toBe("1705329045123000000");
+      });
+
+      it("should format negative Unix nanoseconds for pre-epoch dates", () => {
+        const preEpoch = new Date(-1000000000000); // -1000000000 s
+        const result = formatDate(preEpoch, "unixns");
+        expect(result).toBe("-1000000000000000000");
       });
     });
 

--- a/tests/lib/date-converter.test.ts
+++ b/tests/lib/date-converter.test.ts
@@ -22,8 +22,9 @@ const parseInputDate = (input: string, format = "auto"): Date | null => {
   if (format === "unixns") {
     if (!/^-?\d+$/.test(trimmed)) return null;
     try {
-      const ms = Number(BigInt(trimmed) / BigInt(1_000_000));
-      const d = new Date(ms);
+      const ns = BigInt(trimmed);
+      const msBig = ns / 1_000_000n - (ns < 0n && ns % 1_000_000n !== 0n ? 1n : 0n);
+      const d = new Date(Number(msBig));
       return isNaN(d.getTime()) ? null : d;
     } catch {
       return null;

--- a/tests/lib/date-converter.test.ts
+++ b/tests/lib/date-converter.test.ts
@@ -478,6 +478,12 @@ describe("Date Converter", () => {
         expect(result).toBeNull();
       });
 
+      it("should floor negative Unix nanoseconds when converting to milliseconds", () => {
+        const result = parseInputDate("-1", "unixns");
+        expect(result).toBeInstanceOf(Date);
+        expect(result!.getTime()).toBe(-1);
+      });
+
       it("should parse negative Unix timestamp for pre-epoch dates", () => {
         const result = parseInputDate("-1000000000");
         expect(result).toBeInstanceOf(Date);


### PR DESCRIPTION
Improvements to the date converter

* Support unix epoch in nano seconds
* When now is clicked show now in the selected format